### PR TITLE
Changed the hostname of WebSocket endpoint to correct value

### DIFF
--- a/commands/service/websocket.go
+++ b/commands/service/websocket.go
@@ -21,8 +21,8 @@ type WebsocketListenOptions struct {
 func WebsocketListenCommand(options WebsocketListenOptions) {
 	token := GetToken(*options.Token, *options.Project, "websocket")
 
-	url := "wss://api-dev.sakura.io/ws/v1/" + token
-	origin := "https://api-dev.sakura.io/ws/v1/"
+	url := "wss://api.sakura.io/ws/v1/" + token
+	origin := "https://api.sakura.io/ws/v1/"
 	ws, err := websocket.Dial(url, "", origin)
 	if err != nil {
 		logrus.Fatal(err)

--- a/sakuraio-cli.go
+++ b/sakuraio-cli.go
@@ -9,9 +9,9 @@ import (
 	colorable "github.com/mattn/go-colorable"
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/key/sakuraio-cli/commands"
-	"github.com/key/sakuraio-cli/commands/service"
-	"github.com/key/sakuraio-cli/lib"
+	"github.com/sakura-internet/sakuraio-cli/commands"
+	"github.com/sakura-internet/sakuraio-cli/commands/service"
+	"github.com/sakura-internet/sakuraio-cli/lib"
 )
 
 var (

--- a/sakuraio-cli.go
+++ b/sakuraio-cli.go
@@ -9,9 +9,9 @@ import (
 	colorable "github.com/mattn/go-colorable"
 	"gopkg.in/alecthomas/kingpin.v2"
 
-	"github.com/sakura-internet/sakuraio-cli/commands"
-	"github.com/sakura-internet/sakuraio-cli/commands/service"
-	"github.com/sakura-internet/sakuraio-cli/lib"
+	"github.com/key/sakuraio-cli/commands"
+	"github.com/key/sakuraio-cli/commands/service"
+	"github.com/key/sakuraio-cli/lib"
 )
 
 var (


### PR DESCRIPTION
Hello,

It seems to be set wrong hostname for WebSocket endpoint settings.
I think that the best way should be injected from the outside(environment value or options) at compile time.