### PR TITLE
[datastore] recursive fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# Sakura IoT Platform CLI Tool
+# sakura.io CLI Tool
 
-コマンドライン上で各種操作を行うためのツールです。
-開発中につき、機能が未完成です。
+コマンドライン上でsakura.ioの各種操作を行うためのツールです。
+モジュール登録の自動化・蓄積されたメッセージの一括取得など、運用において便利な機能が実装されています。
+
+内部でのAPI呼び出しの際に、各種サービスごとの使用によって課金が発生する可能性が有ります。詳しくは、ドキュメントをご確認ください。 https://sakura.io/docs/pages/spec/platform/index.html
 
 ## Install
 
 ### Linux/BSD
 
-(arch) の部分は[リリースページ](https://github.com/sakuraio/sakuraio-cli/releases/)
+(version)と(arch) の部分は[リリースページ](https://github.com/sakuraio/sakuraio-cli/releases/)
 から適切なOS/アーキテクチャを選択し、読み替えてください。
 
 ``` bash
-sudo wget (arch) -O /usr/local/bin/sakuraio
+sudo wget https://github.com/sakuraio/sakuraio-cli/releases/download/(version)/sakuraio-cli_(arch) -O /usr/local/bin/sakuraio
 sudo chmod +x /usr/local/bin/sakuraio
 ```
 
@@ -48,6 +50,88 @@ rm -r ~/.sakuraio
 ```
 
 ホームディレクトリに `.sakuraio` ディレクトリを作成して設定を保存しています。
+
+## 使い方
+
+簡単にコマンドの使用方法を紹介します。
+すべての機能は、
+
+### APIキーを設定する
+
+管理APIのAPIキーを取得する必要があります。
+https://sakura.io/docs/pages/guide/api-guide/test-management-api.html
+
+APIキーを取得した後、`auth`コマンドで設定を行います。
+
+```
+# sakuraio auth [key] [secret]
+```
+
+コマンドを実行することで`~/.sakuraio/config.yml`が作成され、認証情報とAPIのBaseURLがセットされます。
+
+```
+apitoken: ********-****-****-****-************
+apisecret: apisecret: ****************************************************************
+baseurl: "https://api.sakura.io/"
+```
+
+### プロジェクトを表示する
+
+最初に`project list`プロジェクトのリストを取得します。
+
+```
+$ sakuraio project list
+ID     ProjectName
+664    sample project
+663    テストプロジェクト
+```
+
+では、ID`664`のプロジェクトの詳細を`project show`コマンドを使用して表示してみます。
+実際のプロジェクトIDは、利用者によって異なるので、読み替えて実行してください。
+
+```
+$ sakuraio project show 664
+ID    ProjectName
+664   sample project
+
+ID       Project    Type                 Token                                   ServiceName
+14014    664        websocket            7d3de3a9-b0e9-48e7-b799-************
+14054    664        datastore            4cbb48ac-d122-4fc9-8aef-************    検証用データストア
+
+ID               Project    Online    ModuleName
+emulator-001     664        false
+```
+
+プロジェクトに設定しているサービス・モジュールが表示されます。
+
+
+### データストアの表示
+
+先程の例で表示したプロジェクトに設定されているDataStoreのサービスを使用し、メッセージの取得を行ってみます。
+トークンは、プロジェクトに設定したdatastoreのトークンとして読み替えてください。
+
+```
+$ service datastore messages --token 4cbb48ac-d122-4fc9-8aef-************
+Module          Datetime                          Type          Payload
+emulator-001    2018-08-22T01:02:54.867058121Z    connection    {"is_online":false}
+emulator-001    2018-08-22T01:02:53.658258856Z    channels      {"channels":[{"channel":0,"datetime":"2018-08-22T01:02:53.658260725Z","type":"l","value":10}]}
+emulator-001    2018-08-22T01:02:53.658874553Z    channels      {"channels":[{"channel":1,"datetime":"2018-08-22T01:02:48.658876312Z","type":"l","value":10}]}
+emulator-001    2018-08-22T01:02:52.657918955Z    channels      {"channels":[{"channel":1,"datetime":"2018-08-22T01:02:47.657920377Z","type":"l","value":9}]}
+emulator-001    2018-08-22T01:02:52.657601773Z    channels      {"channels":[{"channel":0,"datetime":"2018-08-22T01:02:52.657603379Z","type":"l","value":9}]}
+...略
+```
+
+正常に表示されました。次は、表示形式をJSONにし、最近の3件のみ取得してみましょう。
+
+```
+$ sakuraio service datastore messages --token 4cbb48ac-d122-4fc9-8aef-************ --size 3 --raw
+{"id":"349493631385635840","module":"emulator-001","datetime":"2018-08-22T01:02:54.867058121Z","type":"connection","payload":{"is_online":false}}
+{"id":"349493627195891712","module":"emulator-001","datetime":"2018-08-22T01:02:53.658258856Z","type":"channels","payload":{"channels":[{"channel":0,"datetime":"2018-08-22T01:02:53.658260725Z","type":"l","value":10}]}}
+{"id":"349493627195960320","module":"emulator-001","datetime":"2018-08-22T01:02:53.658874553Z","type":"channels","payload":{"channels":[{"channel":1,"datetime":"2018-08-22T01:02:48.658876312Z","type":"l","value":10}]}}
+```
+
+他にも柔軟なオプション指定が行えるので、`sakuraio service datastore messages --help`を実行して確認してください。
+
 
 ## コマンドリファレンス
 
@@ -163,7 +247,8 @@ Commands:
     Get channel data
 
     -m, --module=""        Module ID
-    -s, --size="100"       Fetch Size
+    -s, --size=100         Total fetch count. When 0 is specified fetch
+                           unlimited
         --order=ORDER      Order asc/desc
         --token=TOKEN      Service Token
         --cursor=CURSOR    Cursor
@@ -172,12 +257,16 @@ Commands:
         --channel=CHANNEL  Channel
         --project=PROJECT  Project ID
         --raw              Raw JSON output
+        --no-rec           Un use recursive fetch
+        --max-req=100      Max recursive request count
+        --batch-size=100   Fetch size per request
 
   service datastore messages [<flags>]
     Get message data
 
     -m, --module=""        Module ID
-    -s, --size="100"       Fetch Size
+    -s, --size=100         Total fetch count. When 0 is specified fetch
+                           unlimited
         --order=ORDER      Order asc/desc
         --cursor=CURSOR    Cursor
         --after=AFTER      Datetime range from
@@ -185,6 +274,9 @@ Commands:
         --project=PROJECT  Project ID
         --raw              Raw JSON output
         --token=TOKEN      Service Token
+        --no-rec           Un use recursive fetch
+        --max-req=100      Max recursive request count
+        --batch-size=100   Fetch size per request
 
   service websocket listen [<flags>]
     Listen to Websocket

--- a/commands/service/datastore.go
+++ b/commands/service/datastore.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 	"text/tabwriter"
 
 	"github.com/sakuraio/sakuraio-cli/lib"
@@ -14,7 +13,6 @@ import (
 type DataStoreChannelOptions struct {
 	Module    *string
 	Size      *string
-	Unit      *string
 	Token     *string
 	Order     *string
 	Cursor    *string
@@ -23,6 +21,8 @@ type DataStoreChannelOptions struct {
 	Channel   *string
 	Project   *string
 	RawOutput *bool
+	Recursive *bool
+	MaxReq    *int
 }
 type DataStoreMessagesOption struct {
 	Module    *string
@@ -34,6 +34,8 @@ type DataStoreMessagesOption struct {
 	Project   *string
 	RawOutput *bool
 	Token     *string
+	Recursive *bool
+	MaxReq    *int
 }
 
 func paramSet(values url.Values, key string, value string) {
@@ -52,65 +54,46 @@ func DataStoreChannelsCommand(options DataStoreChannelOptions) {
 		param.Add("module", *options.Module)
 	}
 	paramSet(param, "size", *options.Size)
-	paramSet(param, "unit", *options.Unit)
 	paramSet(param, "order", *options.Order)
 	paramSet(param, "cursor", *options.Cursor)
 	paramSet(param, "after", *options.After)
 	paramSet(param, "before", *options.Before)
 	paramSet(param, "channel", *options.Channel)
 
-	body, err := lib.HTTPGet("datastore/v1/channels?" + param.Encode())
-	checkError("HTTP ERROR", err, body)
-	if *options.RawOutput {
-		fmt.Println(body)
-		return
-	}
+	tabWriter := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
+	lastCursor := ""
 
-	switch *options.Unit {
-	case "channel":
+	for i:=0; i<*options.MaxReq; i++ {
+		if len(lastCursor) != 0 {
+			param.Set("cursor", lastCursor)
+		}
+		body, err := lib.HTTPGet("datastore/v1/channels?" + param.Encode())
+		checkError("HTTP ERROR", err, body)
+		if *options.RawOutput {
+			fmt.Println(body)
+			return
+		}
+
 		var channels ChannelsChannelResponse
 		err = json.Unmarshal([]byte(body), &channels)
 		checkError("JSON format error", err, body)
+		lastCursor = channels.Meta.Cursor
 
-		meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-		fmt.Fprintln(meta, "Count\tMatch\tCursor")
-		fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", channels.Meta.Count, channels.Meta.match, channels.Meta.Cursor)
-		meta.Flush()
+		if !*options.Recursive {
+			meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
+			fmt.Fprintln(meta, "Count\tMatch\tCursor")
+			fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", channels.Meta.Count, channels.Meta.match, channels.Meta.Cursor)
+			meta.Flush()
+		}
 
-		w := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-		fmt.Fprintln(w, "Module\tCh\tType\tValue\tDatetime")
+		if i == 0 {
+			fmt.Fprintln(tabWriter, "Module\tCh\tType\tValue\tDatetime")
+		}
 		for _, v := range channels.Results {
-			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n", v.Module, v.Channel, v.Type, v.ValueStr, v.Datetime)
+			fmt.Fprintf(tabWriter, "%s\t%d\t%s\t%s\t%s\n", v.Module, v.Channel, v.Type, v.ValueStr, v.Datetime)
 		}
-		w.Flush()
-
-	default: // message
-		var messages ChannelsMessageResponse
-		err = json.Unmarshal([]byte(body), &messages)
-		checkError("JSON format error", err, body)
-
-		meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-		fmt.Fprintln(meta, "Count\tMatch\tCursor")
-		fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", messages.Meta.Count, messages.Meta.match, messages.Meta.Cursor)
-		meta.Flush()
-
-		w := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-		fmt.Fprintln(w, "Module\tDatetime\tChannelMessage(ch,type,value,datetime)")
-		for _, v := range messages.Results {
-			for i, c := range v.Channels {
-				value := parseToString(c.Value)
-
-				if i == 0 {
-					fmt.Fprintf(w, "%s\t%s\t%d,%s,%s,%s\n", v.Module, v.Datetime, c.Channel, c.Type, value, c.Datetime)
-				} else {
-					fmt.Fprintf(w, "%s\t%s\t%d,%s,%s,%s\n", "", "", c.Channel, c.Type, value, c.Datetime)
-				}
-
-			}
-		}
-		w.Flush()
+		tabWriter.Flush()
 	}
-
 }
 
 func DataStoreMessagesCmd(options DataStoreMessagesOption) {
@@ -128,51 +111,58 @@ func DataStoreMessagesCmd(options DataStoreMessagesOption) {
 	paramSet(param, "after", *options.After)
 	paramSet(param, "before", *options.Before)
 
-	body, err := lib.HTTPGet("datastore/v1/messages?" + param.Encode())
-	checkError("HTTP ERROR", err, body)
-	if *options.RawOutput {
-		fmt.Println(body)
-		return
+	// use when recursive fetch with cursor
+	isLastLoop := false
+	lastCursor := ""
+	tabWriter := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
+	for i := 0; i < *options.MaxReq; i++ {
+		if len(lastCursor) != 0 {
+			param.Set("cursor", lastCursor)
+		}
+
+		body, err := lib.HTTPGet("datastore/v1/messages?" + param.Encode())
+		checkError("HTTP ERROR", err, body)
+
+		var messages MessagesResponse
+		err = json.Unmarshal([]byte(body), &messages)
+		checkError("JSON format error", err, body)
+
+		lastCursor = messages.Meta.Cursor
+		if len(messages.Results) == 0 {
+			isLastLoop = true
+		}
+		if *options.Recursive && *options.RawOutput {
+			// raw json recursive output
+			for _, row := range messages.Results {
+				str, _ := json.Marshal(row)
+				fmt.Println(string(str))
+			}
+		} else if *options.RawOutput {
+			// raw json output
+			fmt.Println(body)
+		} else {
+			// table layout
+			if !*options.Recursive {
+				meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
+				fmt.Fprintln(meta, "Count\tMatch\tCursor")
+				fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", messages.Meta.Count, messages.Meta.match, messages.Meta.Cursor)
+				meta.Flush()
+			}
+
+			if i == 0 {
+				fmt.Fprintln(tabWriter, "Module\tDatetime\tType\tPayload")
+			}
+			for _, v := range messages.Results {
+				payload, _ := json.Marshal(v.Payload)
+				fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\n", v.Module, v.Datetime, v.Type, payload)
+			}
+			tabWriter.Flush()
+			tabWriter.Flush()
+		}
+		if !*options.Recursive || isLastLoop {
+			break
+		}
 	}
-
-	var messages MessagesResponse
-
-	err = json.Unmarshal([]byte(body), &messages)
-	checkError("JSON format error", err, body)
-
-	meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-	fmt.Fprintln(meta, "Count\tMatch\tCursor")
-	fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", messages.Meta.Count, messages.Meta.match, messages.Meta.Cursor)
-	meta.Flush()
-
-	w := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-	fmt.Fprintln(w, "Module\tDatetime\tType\tPayload")
-	for _, v := range messages.Results {
-		payload, _ := json.Marshal(v.Payload)
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", v.Module, v.Datetime, v.Type, payload)
-	}
-	w.Flush()
-
-}
-
-func parseToString(value interface{}) string {
-	switch value.(type) {
-	case float64:
-		return strconv.FormatFloat(value.(float64), 'f', -1, 64)
-	case string:
-		return value.(string)
-	default:
-		return "***"
-	}
-}
-
-func printProjects(projects []Project) {
-	w := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-	fmt.Fprintln(w, "ID\tProjectName")
-	for _, v := range projects {
-		fmt.Fprintf(w, "%d\t%s\n", v.ID, v.Name)
-	}
-	w.Flush()
 }
 
 type Project struct {
@@ -200,16 +190,17 @@ type ChannelsMessageResponse struct {
 }
 
 type ChannelsMessageResult struct {
-	Module   string
-	Datetime string
-	Channels []ChannelsMessageResultPayload
+	Id       string                         `json:"id"`
+	Module   string                         `json:"module"`
+	Datetime string                         `json:"datetime"`
+	Channels []ChannelsMessageResultPayload `json:"channels"`
 }
 
 type ChannelsMessageResultPayload struct {
-	Channel  int
-	Datetime string
-	Type     string
-	Value    interface{}
+	Channel  int         `json:"channel"`
+	Datetime string      `json:"datetime"`
+	Type     string      `json:"type"`
+	Value    interface{} `json:"value"`
 }
 
 type MessagesResponse struct {
@@ -217,10 +208,11 @@ type MessagesResponse struct {
 	Results []MessagesResult
 }
 type MessagesResult struct {
-	Module   string
-	Datetime string
-	Type     string
-	Payload  interface{}
+	Id       string      `json:"id"`
+	Module   string      `json:"module"`
+	Datetime string      `json:"datetime"`
+	Type     string      `json:"type"`
+	Payload  interface{} `json:"payload"`
 }
 
 type Meta struct {

--- a/commands/service/datastore.go
+++ b/commands/service/datastore.go
@@ -113,7 +113,6 @@ func DataStoreChannelsCommand(options DataStoreChannelOptions) {
 
 		isLastLoop := channels.Meta.Match == 0
 		if *options.NoRecursive || isLastLoop || reamingCount <= 0 {
-			println("exit", isLastLoop, reamingCount)
 			break
 		}
 	}
@@ -189,7 +188,6 @@ func DataStoreMessagesCmd(options DataStoreMessagesOption) {
 		}
 		isLastLoop := messages.Meta.Match == 0
 		if *options.NoRecursive || isLastLoop || reamingCount <= 0 {
-			println("exit", isLastLoop, reamingCount)
 			break
 		}
 	}

--- a/commands/service/datastore.go
+++ b/commands/service/datastore.go
@@ -206,7 +206,7 @@ type ChannelsChannelResponse struct {
 }
 
 type ChannelsChannelResult struct {
-	Channel  int
+	Channel  int     `json:"channel"`
 	Datetime string  `json:"datetime"`
 	Module   string  `json:"module"`
 	Type     string  `json:"type"`

--- a/commands/service/datastore.go
+++ b/commands/service/datastore.go
@@ -8,34 +8,38 @@ import (
 	"text/tabwriter"
 
 	"github.com/sakuraio/sakuraio-cli/lib"
+	"math"
+	"strconv"
 )
 
 type DataStoreChannelOptions struct {
-	Module    *string
-	Size      *string
-	Token     *string
-	Order     *string
-	Cursor    *string
-	After     *string
-	Before    *string
-	Channel   *string
-	Project   *string
-	RawOutput *bool
-	Recursive *bool
-	MaxReq    *int
+	Module      *string
+	Size        *int
+	Token       *string
+	Order       *string
+	Cursor      *string
+	After       *string
+	Before      *string
+	Channel     *string
+	Project     *string
+	RawOutput   *bool
+	NoRecursive *bool
+	MaxReq      *int
+	BatchSize   *int
 }
 type DataStoreMessagesOption struct {
-	Module    *string
-	Size      *string
-	Order     *string
-	Cursor    *string
-	After     *string
-	Before    *string
-	Project   *string
-	RawOutput *bool
-	Token     *string
-	Recursive *bool
-	MaxReq    *int
+	Module      *string
+	Size        *int
+	Order       *string
+	Cursor      *string
+	After       *string
+	Before      *string
+	Project     *string
+	RawOutput   *bool
+	Token       *string
+	NoRecursive *bool
+	MaxReq      *int
+	BatchSize   *int
 }
 
 func paramSet(values url.Values, key string, value string) {
@@ -53,7 +57,7 @@ func DataStoreChannelsCommand(options DataStoreChannelOptions) {
 	if *options.Module != "" {
 		param.Add("module", *options.Module)
 	}
-	paramSet(param, "size", *options.Size)
+	paramSet(param, "size", strconv.Itoa(*options.BatchSize))
 	paramSet(param, "order", *options.Order)
 	paramSet(param, "cursor", *options.Cursor)
 	paramSet(param, "after", *options.After)
@@ -69,30 +73,49 @@ func DataStoreChannelsCommand(options DataStoreChannelOptions) {
 		}
 		body, err := lib.HTTPGet("datastore/v1/channels?" + param.Encode())
 		checkError("HTTP ERROR", err, body)
-		if *options.RawOutput {
-			fmt.Println(body)
-			return
-		}
 
 		var channels ChannelsChannelResponse
 		err = json.Unmarshal([]byte(body), &channels)
 		checkError("JSON format error", err, body)
+
 		lastCursor = channels.Meta.Cursor
+		reamingCount := *options.Size
 
-		if !*options.Recursive {
-			meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
-			fmt.Fprintln(meta, "Count\tMatch\tCursor")
-			fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", channels.Meta.Count, channels.Meta.match, channels.Meta.Cursor)
-			meta.Flush()
+		if *options.NoRecursive && *options.RawOutput {
+			fmt.Println(body)
+		} else if *options.RawOutput {
+			for _, row := range channels.Results {
+				if reamingCount > 0 {
+					str, _ := json.Marshal(row)
+					fmt.Println(string(str))
+				}
+				reamingCount--
+			}
+		} else { // table output
+			if !*options.NoRecursive {
+				meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
+				fmt.Fprintln(meta, "Count\tMatch\tCursor")
+				fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", channels.Meta.Count, channels.Meta.Match, channels.Meta.Cursor)
+				meta.Flush()
+			}
+
+			if i == 0 {
+				fmt.Fprintln(tabWriter, "Module\tCh\tType\tValue\tDatetime")
+			}
+			for _, v := range channels.Results {
+				if reamingCount > 0 {
+					fmt.Fprintf(tabWriter, "%s\t%d\t%s\t%s\t%s\n", v.Module, v.Channel, v.Type, v.ValueStr, v.Datetime)
+				}
+				reamingCount--
+			}
+			tabWriter.Flush()
 		}
 
-		if i == 0 {
-			fmt.Fprintln(tabWriter, "Module\tCh\tType\tValue\tDatetime")
+		isLastLoop := channels.Meta.Match == 0
+		if *options.NoRecursive || isLastLoop || reamingCount <= 0 {
+			println("exit", isLastLoop, reamingCount)
+			break
 		}
-		for _, v := range channels.Results {
-			fmt.Fprintf(tabWriter, "%s\t%d\t%s\t%s\t%s\n", v.Module, v.Channel, v.Type, v.ValueStr, v.Datetime)
-		}
-		tabWriter.Flush()
 	}
 }
 
@@ -105,14 +128,17 @@ func DataStoreMessagesCmd(options DataStoreMessagesOption) {
 	if *options.Module != "" {
 		param.Add("module", *options.Module)
 	}
-	paramSet(param, "size", *options.Size)
+	paramSet(param, "size", strconv.Itoa(*options.BatchSize))
 	paramSet(param, "order", *options.Order)
 	paramSet(param, "cursor", *options.Cursor)
 	paramSet(param, "after", *options.After)
 	paramSet(param, "before", *options.Before)
 
 	// use when recursive fetch with cursor
-	isLastLoop := false
+	reamingCount := *options.Size
+	if reamingCount == 0 {
+		reamingCount = math.MaxInt32
+	}
 	lastCursor := ""
 	tabWriter := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
 	for i := 0; i < *options.MaxReq; i++ {
@@ -128,24 +154,24 @@ func DataStoreMessagesCmd(options DataStoreMessagesOption) {
 		checkError("JSON format error", err, body)
 
 		lastCursor = messages.Meta.Cursor
-		if len(messages.Results) == 0 {
-			isLastLoop = true
-		}
-		if *options.Recursive && *options.RawOutput {
-			// raw json recursive output
+		if !*options.NoRecursive && *options.RawOutput {
+			// raw json recursive output in recursive
 			for _, row := range messages.Results {
-				str, _ := json.Marshal(row)
-				fmt.Println(string(str))
+				if reamingCount > 0 {
+					str, _ := json.Marshal(row)
+					fmt.Println(string(str))
+				}
+				reamingCount--
 			}
 		} else if *options.RawOutput {
 			// raw json output
 			fmt.Println(body)
 		} else {
 			// table layout
-			if !*options.Recursive {
+			if *options.NoRecursive {
 				meta := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
 				fmt.Fprintln(meta, "Count\tMatch\tCursor")
-				fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", messages.Meta.Count, messages.Meta.match, messages.Meta.Cursor)
+				fmt.Fprintf(meta, "%d\t%d\t%s\n---\n", messages.Meta.Count, messages.Meta.Match, messages.Meta.Cursor)
 				meta.Flush()
 			}
 
@@ -153,13 +179,17 @@ func DataStoreMessagesCmd(options DataStoreMessagesOption) {
 				fmt.Fprintln(tabWriter, "Module\tDatetime\tType\tPayload")
 			}
 			for _, v := range messages.Results {
-				payload, _ := json.Marshal(v.Payload)
-				fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\n", v.Module, v.Datetime, v.Type, payload)
+				if reamingCount > 0 {
+					payload, _ := json.Marshal(v.Payload)
+					fmt.Fprintf(tabWriter, "%s\t%s\t%s\t%s\n", v.Module, v.Datetime, v.Type, payload)
+				}
+				reamingCount--
 			}
 			tabWriter.Flush()
-			tabWriter.Flush()
 		}
-		if !*options.Recursive || isLastLoop {
+		isLastLoop := messages.Meta.Match == 0
+		if *options.NoRecursive || isLastLoop || reamingCount <= 0 {
+			println("exit", isLastLoop, reamingCount)
 			break
 		}
 	}
@@ -177,9 +207,9 @@ type ChannelsChannelResponse struct {
 
 type ChannelsChannelResult struct {
 	Channel  int
-	Datetime string
-	Module   string
-	Type     string
+	Datetime string  `json:"datetime"`
+	Module   string  `json:"module"`
+	Type     string  `json:"type"`
 	ValueNum float64 `json:"value_num"`
 	ValueStr string  `json:"value_str"`
 }
@@ -218,5 +248,5 @@ type MessagesResult struct {
 type Meta struct {
 	Count  int
 	Cursor string
-	match  int
+	Match  int
 }

--- a/commands/service/datastore.go
+++ b/commands/service/datastore.go
@@ -63,7 +63,7 @@ func DataStoreChannelsCommand(options DataStoreChannelOptions) {
 	tabWriter := tabwriter.NewWriter(os.Stdout, 3, 0, 4, ' ', 0)
 	lastCursor := ""
 
-	for i:=0; i<*options.MaxReq; i++ {
+	for i := 0; i < *options.MaxReq; i++ {
 		if len(lastCursor) != 0 {
 			param.Set("cursor", lastCursor)
 		}

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,5 +1,5 @@
 package commands
 
 const (
-  Version = "0.1.2"
+	Version = "0.1.2"
 )

--- a/commands/version.go
+++ b/commands/version.go
@@ -1,5 +1,5 @@
 package commands
 
 const (
-	Version = "0.1.2"
+	Version = "0.1.3"
 )

--- a/lib/setting.go
+++ b/lib/setting.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v2"
-	"github.com/Sirupsen/logrus"
 )
 
 const DEFAULT_CONFIG_PATH = "./.sakuraio/config.yml"

--- a/lib/setting.go
+++ b/lib/setting.go
@@ -1,13 +1,13 @@
 package lib
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v2"
+	"github.com/Sirupsen/logrus"
 )
 
 const DEFAULT_CONFIG_PATH = "./.sakuraio/config.yml"
@@ -18,11 +18,9 @@ func getDefaultConfigPath() string {
 }
 
 func GetSetting() Settings {
-	setting := Settings{}
 	setting, err := GetUserSetting()
 	if err != nil {
-		fmt.Println(setting)
-		return setting
+		logrus.WithError(err).Warn("Cannot read configure file. Use default config.")
 	}
 
 	if setting.BaseURL == "" {

--- a/sakuraio-cli.go
+++ b/sakuraio-cli.go
@@ -17,7 +17,7 @@ import (
 var (
 	_, commandName = path.Split(os.Args[0])
 
-	app = kingpin.New(commandName , "sakuraio client command")
+	app = kingpin.New(commandName, "sakuraio client command")
 
 	appToken  = app.Flag("api-token", "API Token").String()
 	appSecret = app.Flag("api-secret", "API Secret").String()

--- a/sakuraio-cli.go
+++ b/sakuraio-cli.go
@@ -6,7 +6,7 @@ import (
 	"path"
 
 	"github.com/Sirupsen/logrus"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/mattn/go-colorable"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/sakuraio/sakuraio-cli/commands"
@@ -70,31 +70,33 @@ var (
 	DataStoreMessagesCmd = dataStoreCmd.Command("messages", "Get message data")
 )
 var dataStoreChannelOption = service.DataStoreChannelOptions{
-	Module:    DataStoreChannelsCmd.Flag("module", "Module ID").Short('m').Default("").String(),
-	Size:      DataStoreChannelsCmd.Flag("size", "Fetch Size").Short('s').Default("100").String(),
-	Order:     DataStoreChannelsCmd.Flag("order", "Order asc/desc").String(),
-	Token:     DataStoreChannelsCmd.Flag("token", "Service Token").String(),
-	Cursor:    DataStoreChannelsCmd.Flag("cursor", "Cursor").String(),
-	After:     DataStoreChannelsCmd.Flag("after", "Datetime range from").String(),
-	Before:    DataStoreChannelsCmd.Flag("before", "Datetime range to").String(),
-	Channel:   DataStoreChannelsCmd.Flag("channel", "Channel").String(),
-	Project:   DataStoreChannelsCmd.Flag("project", "Project ID").String(),
-	RawOutput: DataStoreChannelsCmd.Flag("raw", "Raw JSON output").Default("false").Bool(),
-	Recursive: DataStoreChannelsCmd.Flag("recursive", "Collect recursive").Short('r').Default("false").Bool(),
-	MaxReq:    DataStoreChannelsCmd.Flag("max-req", "Max request count in --recursive").Default("100").Int(),
+	Module:      DataStoreChannelsCmd.Flag("module", "Module ID").Short('m').Default("").String(),
+	Size:        DataStoreChannelsCmd.Flag("size", "Total fetch count. When 0 is specified fetch unlimited").Short('s').Default("100").Int(),
+	Order:       DataStoreChannelsCmd.Flag("order", "Order asc/desc").String(),
+	Token:       DataStoreChannelsCmd.Flag("token", "Service Token").String(),
+	Cursor:      DataStoreChannelsCmd.Flag("cursor", "Cursor").String(),
+	After:       DataStoreChannelsCmd.Flag("after", "Datetime range from").String(),
+	Before:      DataStoreChannelsCmd.Flag("before", "Datetime range to").String(),
+	Channel:     DataStoreChannelsCmd.Flag("channel", "Channel").String(),
+	Project:     DataStoreChannelsCmd.Flag("project", "Project ID").String(),
+	RawOutput:   DataStoreChannelsCmd.Flag("raw", "Raw JSON output").Default("false").Bool(),
+	NoRecursive: DataStoreChannelsCmd.Flag("no-rec", "Un use recursive fetch").Default("false").Bool(),
+	MaxReq:      DataStoreChannelsCmd.Flag("max-req", "Max recursive request count").Default("100").Int(),
+	BatchSize:   DataStoreChannelsCmd.Flag("batch-size", "Fetch size per request").Default("100").Int(),
 }
 var dataStoreMessageOption = service.DataStoreMessagesOption{
-	Module:    DataStoreMessagesCmd.Flag("module", "Module ID").Short('m').Default("").String(),
-	Size:      DataStoreMessagesCmd.Flag("size", "Fetch Size").Short('s').Default("100").String(),
-	Order:     DataStoreMessagesCmd.Flag("order", "Order asc/desc").String(),
-	Cursor:    DataStoreMessagesCmd.Flag("cursor", "Cursor").String(),
-	After:     DataStoreMessagesCmd.Flag("after", "Datetime range from").String(),
-	Before:    DataStoreMessagesCmd.Flag("before", "Datetime range to").String(),
-	Project:   DataStoreMessagesCmd.Flag("project", "Project ID").String(),
-	RawOutput: DataStoreMessagesCmd.Flag("raw", "Raw JSON output").Default("false").Bool(),
-	Token:     DataStoreMessagesCmd.Flag("token", "Service Token").String(),
-	Recursive: DataStoreMessagesCmd.Flag("recursive", "Collect recursive").Short('r').Default("false").Bool(),
-	MaxReq:    DataStoreMessagesCmd.Flag("max-req", "Max request count in --recursive").Default("100").Int(),
+	Module:      DataStoreMessagesCmd.Flag("module", "Module ID").Short('m').Default("").String(),
+	Size:        DataStoreMessagesCmd.Flag("size", "Total fetch count. When 0 is specified fetch unlimited").Short('s').Default("100").Int(),
+	Order:       DataStoreMessagesCmd.Flag("order", "Order asc/desc").String(),
+	Cursor:      DataStoreMessagesCmd.Flag("cursor", "Cursor").String(),
+	After:       DataStoreMessagesCmd.Flag("after", "Datetime range from").String(),
+	Before:      DataStoreMessagesCmd.Flag("before", "Datetime range to").String(),
+	Project:     DataStoreMessagesCmd.Flag("project", "Project ID").String(),
+	RawOutput:   DataStoreMessagesCmd.Flag("raw", "Raw JSON output").Default("false").Bool(),
+	Token:       DataStoreMessagesCmd.Flag("token", "Service Token").String(),
+	NoRecursive: DataStoreMessagesCmd.Flag("no-rec", "Un use recursive fetch").Default("false").Bool(),
+	MaxReq:      DataStoreMessagesCmd.Flag("max-req", "Max recursive request count").Default("100").Int(),
+	BatchSize:   DataStoreMessagesCmd.Flag("batch-size", "Fetch size per request").Default("100").Int(),
 }
 
 var (

--- a/sakuraio-cli.go
+++ b/sakuraio-cli.go
@@ -72,7 +72,6 @@ var (
 var dataStoreChannelOption = service.DataStoreChannelOptions{
 	Module:    DataStoreChannelsCmd.Flag("module", "Module ID").Short('m').Default("").String(),
 	Size:      DataStoreChannelsCmd.Flag("size", "Fetch Size").Short('s').Default("100").String(),
-	Unit:      DataStoreChannelsCmd.Flag("unit", "Unit channel/message").Hidden().String(),
 	Order:     DataStoreChannelsCmd.Flag("order", "Order asc/desc").String(),
 	Token:     DataStoreChannelsCmd.Flag("token", "Service Token").String(),
 	Cursor:    DataStoreChannelsCmd.Flag("cursor", "Cursor").String(),
@@ -81,6 +80,8 @@ var dataStoreChannelOption = service.DataStoreChannelOptions{
 	Channel:   DataStoreChannelsCmd.Flag("channel", "Channel").String(),
 	Project:   DataStoreChannelsCmd.Flag("project", "Project ID").String(),
 	RawOutput: DataStoreChannelsCmd.Flag("raw", "Raw JSON output").Default("false").Bool(),
+	Recursive: DataStoreChannelsCmd.Flag("recursive", "Collect recursive").Short('r').Default("false").Bool(),
+	MaxReq:    DataStoreChannelsCmd.Flag("max-req", "Max request count in --recursive").Default("100").Int(),
 }
 var dataStoreMessageOption = service.DataStoreMessagesOption{
 	Module:    DataStoreMessagesCmd.Flag("module", "Module ID").Short('m').Default("").String(),
@@ -92,6 +93,8 @@ var dataStoreMessageOption = service.DataStoreMessagesOption{
 	Project:   DataStoreMessagesCmd.Flag("project", "Project ID").String(),
 	RawOutput: DataStoreMessagesCmd.Flag("raw", "Raw JSON output").Default("false").Bool(),
 	Token:     DataStoreMessagesCmd.Flag("token", "Service Token").String(),
+	Recursive: DataStoreMessagesCmd.Flag("recursive", "Collect recursive").Short('r').Default("false").Bool(),
+	MaxReq:    DataStoreMessagesCmd.Flag("max-req", "Max request count in --recursive").Default("100").Int(),
 }
 
 var (


### PR DESCRIPTION
## service datastore

### コマンドの動作・オプションの変更

カーソルを使用した取得に対応し、5000件など1回のリクエストで取得できないメッセージ数の取得に対応しました。

上記の変更を行うに当たりオプションの意味の変更・追加を行いました。

- `--size` は全体の取得件数
- `--batch-size` は1度あたりの取得件数
- `--max-req=100` は再帰的に取得を行う時の上限リクエスト回数
- `--no-rec` は再帰的な取得を無効にする

### idフィールドの追加

表示されるフィールドにメッセージのIDを追加しました。